### PR TITLE
chore(*): updates per brigadecore org transfer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Azure/brigade"
+  name = "github.com/brigadecore/brigade"
   packages = [
     "pkg/brigade",
     "pkg/merge",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **This is considered experimental and pre-Alpha. Do not use it in production.**
 
-This is a [Brigade](https://github.com/Azure/brigade) gateway that provides a
+This is a [Brigade](https://github.com/brigadecore/brigade) gateway that provides a
 GitHub App with deep integration to GitHub's new Check API.
 
 ![screenshot](docs/screenshot.png)
@@ -54,7 +54,7 @@ step.
 ### 2. Install the Helm chart into your cluster
 
 The [Brigade Github App Helm Chart][brigade-github-app-chart] is hosted at the
-[Azure/brigade-charts][brigade-charts] repository.
+[brigadecore/charts][charts] repository.
 
 You must install this gateway into the same namespace in your cluster where
 Brigade is already running.
@@ -64,7 +64,7 @@ either by setting the Service to be a load balancer, or setting up the Ingress. 
 STRONGLY recommend setting up an ingress to use Kube-LEGO or another SSL proxy.
 
 ```
-$ helm repo add brigade https://azure.github.io/brigade-charts
+$ helm repo add brigade https://brigadecore.github.io/charts
 $ helm inspect values brigade/brigade-github-app > values.yaml
 $ # Edit values.yaml
 $ helm install -n gh-app brigade/brigade-github-app
@@ -324,5 +324,5 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-[brigade-charts]: https://github.com/Azure/brigade-charts
-[brigade-github-app-chart]: https://github.com/Azure/brigade-charts/tree/master/charts/brigade-github-app
+[charts]: https://github.com/brigadecore/charts
+[brigade-github-app-chart]: https://github.com/brigadecore/charts/tree/master/charts/brigade-github-app

--- a/brigade.js
+++ b/brigade.js
@@ -1,6 +1,6 @@
 const { events, Job, Group } = require("brigadier")
 
-const projectOrg = "Azure"
+const projectOrg = "brigadecore"
 const projectName = "brigade-github-app"
 
 const goImg = "golang:1.11"
@@ -116,7 +116,7 @@ class Notification {
       this.payload = e.payload;
       this.name = name;
       this.externalID = e.buildID;
-      this.detailsURL = `https://azure.github.io/kashti/builds/${ e.buildID }`;
+      this.detailsURL = `https://brigadecore.github.io/kashti/builds/${ e.buildID }`;
       this.title = "running check";
       this.text = "";
       this.summary = "";

--- a/cmd/check-run/main.go
+++ b/cmd/check-run/main.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/brigade-github-app/pkg/check"
-	"github.com/Azure/brigade-github-app/pkg/webhook"
+	"github.com/brigadecore/brigade-github-app/pkg/check"
+	"github.com/brigadecore/brigade-github-app/pkg/webhook"
 
 	"github.com/google/go-github/github"
 )

--- a/cmd/github-gateway/server.go
+++ b/cmd/github-gateway/server.go
@@ -13,9 +13,9 @@ import (
 	gin "gopkg.in/gin-gonic/gin.v1"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/Azure/brigade/pkg/storage/kube"
+	"github.com/brigadecore/brigade/pkg/storage/kube"
 
-	"github.com/Azure/brigade-github-app/pkg/webhook"
+	"github.com/brigadecore/brigade-github-app/pkg/webhook"
 )
 
 var (

--- a/golangci.yml
+++ b/golangci.yml
@@ -16,4 +16,4 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/Azure/brigade-github-app
+    local-prefixes: github.com/brigadecore/brigade-github-app

--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 
-	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/brigade"
 )
 
 // State names for GitHub status

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"testing"
 
-	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/brigade"
 )
 
 func TestGHClient(t *testing.T) {

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -14,8 +14,8 @@ import (
 	"github.com/google/go-github/github"
 	gin "gopkg.in/gin-gonic/gin.v1"
 
-	"github.com/Azure/brigade/pkg/brigade"
-	"github.com/Azure/brigade/pkg/storage"
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/storage"
 )
 
 const hubSignatureHeader = "X-Hub-Signature"

--- a/pkg/webhook/github_test.go
+++ b/pkg/webhook/github_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-github/github"
 	gin "gopkg.in/gin-gonic/gin.v1"
 
-	"github.com/Azure/brigade/pkg/brigade"
-	"github.com/Azure/brigade/pkg/storage"
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/storage"
 )
 
 type testStore struct {


### PR DESCRIPTION
Updates needed in anticipation of the org move to `brigadecore`.

Please comment on/identify other changes that may also be needed.

Related: 
https://github.com/Azure/brigade/pull/847
https://github.com/Azure/brigade-charts/pull/36