### PR TITLE
emit events qualified by action

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,66 @@ really receive will be much more detailed.
 
 ### Events Emitted by this Gateway
 
-This gateway emits the following events:
+Select events received by this gateway from Github are, in turn, emitted into
+Brigade. In some cases, events received from Github contain an `action` field.
+For all such events, _two_ events will be emitted into Brigade. One will be a
+coarse-grained event, unaqualified by `action`. The second will be more
+finely-grained and qualified by `action`. The latter permits Brigade users to to
+more easily subscribe to a relevant subset of events that are of interest to
+them. For instance, if a user is interested in subscribing only to events that
+indicate a new pull request was opened, they may subscribe to
+`pull_request:opened` instead of subscribing to the more broad `pull_request`
+event, which would have burdened the user with writing logic to select on the
+basis of `action` themselves.
 
-- `check_suite:requested`: When a new request is opened
-- `check_suite:rerequested`: When checks are requested again
-- `check_suite:completed`: When a check suite is completed
-- `check_run:created`: When an individual test is requested
-- `check_run:updated`: When an individual test is updated with new status
-- `check_run:rerequested`: When an individual test is re-requested
+The events emitted by this gateway into Brigade are:
+
+- `check_run`: A check run event with any `action`. A second event qualified by `action` will _also_ be emitted.
+- `check_run:completed`: The `status` of a check run was updated to `completed`.
+- `check_run:created`: A new check run was created.
+- `check_run:requested_action`: Someone requested that an action be taken.
+- `check_run:rerequested`: Someone requested to re-run your check run.
+- `check_suite:completed`: The `status` of a check suite was updated to `completed`.
+- `check_suite:requested`: A new check suite was created.
+- `check_suite:rerequested`: Someone requested to re-run your check suite.
+- `commit_comment`: A commit comment event with any `action`. A second event qualified by `action` will _also_ be emitted.
+- `commit_comment:created`: A commit comment was created.
+- `create`: A branch or tag was created.
+- `deployment`: A deployment was created.
+- `deployment_status`: A deployment's sdtatus has changed.
+- `pull_request`: A pull request event with any `action`. A second event qualified by `action` will _also_ be emitted.
+- `pull_request:assigned`: A pull request was assigned.
+- `pull_request:closed`: A pull request was closed.
+- `pull_request:edited`: A pull request was edited (e.g. title or body is edited).
+- `pull_request:labeled`: A new label was assigned to a pull request.
+- `pull_request:locked`: A pull request was locked.
+- `pull_request:opened`: A new pull request was opened.
+- `pull_request:ready_for_review`: A pull request is ready for review.
+- `pull_request:reopened`: A closed pulled request was re-opened.
+- `pull_request:review_request_removed`: An existing request for pull request review was removed.
+- `pull_request:review_requested`: A pull request review was re-requested.
+- `pull_request:unassigned`: A pull request was unassigned.
+- `pull_request:unlabeled`: A label was removed from a pull request.
+- `pull_request:unlocked`: A pull request was unlocked.
+- `pull_request_review`: A pull request review with any `action`. A second event qualified by `action` will _also_ be emitted.
+- `pull_request_review:submitted`: A pull request review was submitted.
+- `pull_request_review:edited`: A pull request review was edited.
+- `pull_request_review:dismissed`: A pull request review was dismissed.
+- `pull_request_review_comment`: A pull request review comment with any `action`. A second event qualified by `action` will _also_ be emitted.
+- `pull_request_review_comment:created`: A new pull request review comment was created.
+- `pull_request_review_comment:deleted`: An existing pull request review comment was deleted.
+- `pull_request_review_comment:edited`: An existing pull request review comment was edited.
+- `push`: A commit was pushed to a branch or a new tag was applied.
+- `release`: A release event with any `action`. A second event qualified by `action` will _also_ be emitted.
+- `release:created`: A new release was created.
+- `release:deleted`: An existing release was deleted.
+- `release:edited`: An existing release was edited.
+- `release:prereleased`: A release is pre-released.
+- `release:published`: A release is published.
+- `release:unpublished`: A release is unpublished.
+- `status`: The status of a git commit was changed.
+
+Each of these events is described in greater detail in [Github's own API documentation](https://developer.github.com/v3/activity/events/types/).
 
 The `check_suite` events will let you start all of your tests at once, while the
 `check_run` events will let you work with individual tests. The example in the

--- a/pkg/webhook/github_test.go
+++ b/pkg/webhook/github_test.go
@@ -56,18 +56,19 @@ func newTestGithubHandler(store storage.Store, t *testing.T) *githubHook {
 func TestGithubHandler(t *testing.T) {
 
 	tests := []struct {
-		event        string
-		commit       string
-		ref          string
-		payloadFile  string
-		renamedEvent string
-		mustFail     bool
+		event          string
+		commit         string
+		ref            string
+		payloadFile    string
+		mustFail       bool
+		expectedBuilds []string
 	}{
 		{
-			event:       "push",
-			commit:      "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
-			ref:         "refs/heads/changes",
-			payloadFile: "testdata/github-push-payload.json",
+			event:          "push",
+			commit:         "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+			ref:            "refs/heads/changes",
+			payloadFile:    "testdata/github-push-payload.json",
+			expectedBuilds: []string{"push"},
 		},
 		{
 			event:       "push",
@@ -83,61 +84,70 @@ func TestGithubHandler(t *testing.T) {
 			mustFail:    true,
 		},
 		{
-			event:       "pull_request",
-			ref:         "refs/pull/1/head",
-			commit:      "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
-			payloadFile: "testdata/github-pull_request-payload.json",
+			event:          "pull_request",
+			ref:            "refs/pull/1/head",
+			commit:         "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+			payloadFile:    "testdata/github-pull_request-payload.json",
+			expectedBuilds: []string{"pull_request", "pull_request:opened"},
 		},
 		{
-			event:       "pull_request_review",
-			commit:      "b7a1f9c27caa4e03c14a88feb56e2d4f7500aa63",
-			ref:         "refs/pull/8/head",
-			payloadFile: "testdata/github-pull_request_review-payload.json",
+			event:          "pull_request_review",
+			commit:         "b7a1f9c27caa4e03c14a88feb56e2d4f7500aa63",
+			ref:            "refs/pull/8/head",
+			payloadFile:    "testdata/github-pull_request_review-payload.json",
+			expectedBuilds: []string{"pull_request_review", "pull_request_review:submitted"},
 		},
 		{
-			event:        "pull_request",
-			commit:       "ad0703ac08e80448764b34dc089d0f73a1242ae9",
-			ref:          "refs/pull/1/head",
-			payloadFile:  "testdata/github-pull_request-labeled-payload.json",
-			renamedEvent: "pull_request:labeled",
+			event:          "pull_request",
+			commit:         "ad0703ac08e80448764b34dc089d0f73a1242ae9",
+			ref:            "refs/pull/1/head",
+			payloadFile:    "testdata/github-pull_request-labeled-payload.json",
+			expectedBuilds: []string{"pull_request", "pull_request:labeled"},
 		},
 		{
-			event:       "status",
-			commit:      "9049f1265b7d61be4a8904a9a27120d2064dab3b",
-			payloadFile: "testdata/github-status-payload.json",
+			event:          "status",
+			commit:         "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+			payloadFile:    "testdata/github-status-payload.json",
+			expectedBuilds: []string{"status"},
 		},
 		{
-			event:       "release",
-			ref:         "0.0.1",
-			payloadFile: "testdata/github-release-payload.json",
+			event:          "release",
+			ref:            "0.0.1",
+			payloadFile:    "testdata/github-release-payload.json",
+			expectedBuilds: []string{"release", "release:published"},
 		},
 		{
-			event:       "create",
-			ref:         "0.0.1",
-			payloadFile: "testdata/github-create-payload.json",
+			event:          "create",
+			ref:            "0.0.1",
+			payloadFile:    "testdata/github-create-payload.json",
+			expectedBuilds: []string{"create"},
 		},
 		{
-			event:       "commit_comment",
-			commit:      "9049f1265b7d61be4a8904a9a27120d2064dab3b",
-			payloadFile: "testdata/github-commit_comment-payload.json",
+			event:          "commit_comment",
+			commit:         "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+			payloadFile:    "testdata/github-commit_comment-payload.json",
+			expectedBuilds: []string{"commit_comment", "commit_comment:created"},
 		},
 		{
-			event:       "deployment",
-			commit:      "9049f1265b7d61be4a8904a9a27120d2064dab3b",
-			ref:         "master",
-			payloadFile: "testdata/github-deployment-payload.json",
+			event:          "deployment",
+			commit:         "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+			ref:            "master",
+			payloadFile:    "testdata/github-deployment-payload.json",
+			expectedBuilds: []string{"deployment"},
 		},
 		{
-			event:       "deployment_status",
-			commit:      "9049f1265b7d61be4a8904a9a27120d2064dab3b",
-			ref:         "master",
-			payloadFile: "testdata/github-deployment_status-payload.json",
+			event:          "deployment_status",
+			commit:         "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+			ref:            "master",
+			payloadFile:    "testdata/github-deployment_status-payload.json",
+			expectedBuilds: []string{"deployment_status"},
 		},
 		{
-			event:       "pull_request_review_comment",
-			commit:      "34c5c7793cb3b279e22454cb6750c80560547b3a",
-			ref:         "refs/pull/1/head",
-			payloadFile: "testdata/github-pull_request_review_comment-payload.json",
+			event:          "pull_request_review_comment",
+			commit:         "34c5c7793cb3b279e22454cb6750c80560547b3a",
+			ref:            "refs/pull/1/head",
+			payloadFile:    "testdata/github-pull_request_review_comment-payload.json",
+			expectedBuilds: []string{"pull_request_review_comment", "pull_request_review_comment:created"},
 		},
 	}
 
@@ -190,25 +200,36 @@ func TestGithubHandler(t *testing.T) {
 				return
 			}
 
-			if len(store.builds) != 1 {
-				t.Fatal("expected a build created")
+			if len(store.builds) != len(tt.expectedBuilds) {
+				t.Fatalf(
+					"expected %d build(s) but %d build(s) were created",
+					len(tt.expectedBuilds),
+					len(store.builds),
+				)
 			}
-			if ee := store.builds[0].Type; tt.renamedEvent != "" {
-				if ee != tt.renamedEvent {
-					t.Errorf("Build.Type is not correct. Expected renamed event %q, got %q", tt.renamedEvent, ee)
+			for i, build := range store.builds {
+				if build.Type != tt.expectedBuilds[i] {
+					t.Errorf(
+						"store.builds[%d].Type is not correct. Expected %q, got %q",
+						i,
+						tt.expectedBuilds[i],
+						build.Type,
+					)
 				}
-			} else if ee != tt.event {
-				t.Errorf("Build.Type is not correct. Expected event %q, got %q", tt.event, ee)
-			}
-			b := store.builds[0]
-			if b.Provider != "github" {
-				t.Error("Build.Provider is not correct")
-			}
-			if b.Revision.Commit != tt.commit {
-				t.Error("Build.Commit is not correct")
-			}
-			if b.Revision.Ref != tt.ref {
-				t.Errorf("Build.Commit is not correct. Expected ref %q, got %q", tt.ref, b.Revision.Ref)
+				if build.Provider != "github" {
+					t.Errorf("store.builds[%d].Provider is not correct", i)
+				}
+				if build.Revision.Commit != tt.commit {
+					t.Errorf("store.builds[%d].Commit is not correct", i)
+				}
+				if build.Revision.Ref != tt.ref {
+					t.Errorf(
+						"store.builds[%d].Commit is not correct. Expected ref %q, got %q",
+						i,
+						tt.ref,
+						build.Revision.Ref,
+					)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #49 
Fixes #48 

This should, in _all_ cases where an incoming event has an `action` field, emit _both_ an "unqualified" event into Brigade _and_ an event qualified by action. For instance, where `pull_request` was once emitted, now both `pull_request` and `pull_request:<action>` are emitted.

Note that in some cases we were previously emitting _only_ unqualified events (e.g. `pull_request`) and in other cases we were emitting _only_ qualified events (e.g. `check_suite:requested`). This PR ensures consistency across the board.

I'll take a moment to also proactively point out that this is not a breaking change. Anyone not already subscribed to an event that didn't previously exist cannot be adversely affected by its introduction.

The net effect of this PR is that users can now _easily_ subscribe to events that are qualified by action, such as `pull_request:opened` and easily distinguish between the likes of `pull_request:opened` and `pull_request:closed` without having to parse the payload to determine if an event is even of interest.