### PR TITLE
allow a default shared secret to be configured

### DIFF
--- a/cmd/github-gateway/server.go
+++ b/cmd/github-gateway/server.go
@@ -94,8 +94,9 @@ func main() {
 	}
 
 	ghOpts := webhook.GithubOpts{
-		CheckSuiteOnPR: envOrBool("CHECK_SUITE_ON_PR", true),
-		AppID:          envOrInt("APP_ID", 0),
+		CheckSuiteOnPR:      envOrBool("CHECK_SUITE_ON_PR", true),
+		AppID:               envOrInt("APP_ID", 0),
+		DefaultSharedSecret: os.Getenv("DEFAULT_SHARED_SECRET"),
 	}
 
 	clientset, err := kube.GetClient(master, kubeconfig)

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -38,8 +38,9 @@ type githubHook struct {
 // GithubOpts provides options for configuring a GitHub hook
 type GithubOpts struct {
 	// CheckSuiteOnPR will trigger a check suite run for new PRs that pass the security params.
-	CheckSuiteOnPR bool
-	AppID          int
+	CheckSuiteOnPR      bool
+	AppID               int
+	DefaultSharedSecret string
 }
 
 type fileGetter func(commit, path string, proj *brigade.Project) ([]byte, error)
@@ -167,13 +168,17 @@ func (s *githubHook) handleCheck(c *gin.Context, eventType string) {
 		return
 	}
 
-	if proj.SharedSecret == "" {
+	var sharedSecret = proj.SharedSecret
+	if sharedSecret == "" {
+		sharedSecret = s.opts.DefaultSharedSecret
+	}
+	if sharedSecret == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "No secret is configured for this repo."})
 		return
 	}
 
 	signature := c.Request.Header.Get(hubSignatureHeader)
-	if err := validateSignature(signature, proj.SharedSecret, body); err != nil {
+	if err := validateSignature(signature, sharedSecret, body); err != nil {
 		c.JSON(http.StatusForbidden, gin.H{"status": "malformed signature"})
 		return
 	}
@@ -300,13 +305,17 @@ func (s *githubHook) handleEvent(c *gin.Context, eventType string) {
 		return
 	}
 
-	if proj.SharedSecret == "" {
+	var sharedSecret = proj.SharedSecret
+	if sharedSecret == "" {
+		sharedSecret = s.opts.DefaultSharedSecret
+	}
+	if sharedSecret == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "No secret is configured for this repo."})
 		return
 	}
 
 	signature := c.Request.Header.Get(hubSignatureHeader)
-	if err := validateSignature(signature, proj.SharedSecret, body); err != nil {
+	if err := validateSignature(signature, sharedSecret, body); err != nil {
 		c.JSON(http.StatusForbidden, gin.H{"status": "malformed signature"})
 		return
 	}


### PR DESCRIPTION
Currently, shared secrets are shared between Github App configuration (_on_ Github) and _projects_. But it may often make sense to configure a shared secret per _Github gateway_ instead of per project. This allows for that possibility without affecting existing behavior. If no shared secret is specified at the project level, the gateway falls back to an option default that it obtains from an environment variable.

Note that _currently_ it's not possible to create projects with no shared secret, however, when addressing https://github.com/brigadecore/brigade/issues/907, I intend to allow for that possibility. i.e. Let users choose between auto-generating a shared secret (as is done today), bringing their own, or _not_ specifying one at all, to allow this graceful fallback to the gateway's default shared secret.

__Edit:__ Naturally, if this is merged, I will follow-up with a PR to the Helm chart to surface this default, gateway-level shared secret option to operators.

Signed-off-by: Kent Rancourt <kent.rancourt@microsoft.com>