### PR TITLE
build / release fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ SHELL ?= /bin/bash
 # Version details                                                              #
 ################################################################################
 
-GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
+# This will reliably return the short SHA1 of HEAD or, if the working directory
+# is dirty, will return that + "-dirty"
+GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtCh)
 
 ################################################################################
 # Go build details                                                             #

--- a/brigade.js
+++ b/brigade.js
@@ -1,15 +1,13 @@
-const { events, Job, Group } = require("brigadier")
+const { events, Job } = require("brigadier");
 
-const projectOrg = "brigadecore"
-const projectName = "brigade-github-app"
+const projectOrg = "brigadecore";
+const projectName = "brigade-github-app";
 
-const goImg = "quay.io/deis/lightweight-docker-go:v0.6.0"
-const gopath = "/go"
+const goImg = "quay.io/deis/lightweight-docker-go:v0.6.0";
+const gopath = "/go";
 const localPath = gopath + `/src/github.com/${projectOrg}/${projectName}`;
 
-const noop = {run: () => {return Promise.resolve()}}
-
-const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
+const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/;
 
 function test() {
   // Create a new job to run Go tests
@@ -24,7 +22,7 @@ function test() {
     `cd ${localPath}`,
     "make verify-vendored-code lint test"
   ];
-  return job
+  return job;
 }
 
 function buildAndPublishImages(project, version) {
@@ -58,89 +56,85 @@ function runSuite(e, p) {
 
 // runTests is a Check Run that is run as part of a Checks Suite
 function runTests(e, p) {
-  console.log("Check requested")
+  console.log("Check requested");
 
   // Create Notification object (which is just a Job to update GH using the Checks API)
   var note = new Notification(`tests`, e, p);
   note.conclusion = "";
   note.title = "Run Tests";
   note.summary = "Running the test targets for " + e.revision.commit;
-  note.text = "This test will ensure build, linting and tests all pass."
+  note.text = "This test will ensure build, linting and tests all pass.";
 
   // Send notification, then run, then send pass/fail notification
-  return notificationWrap(test(), note)
+  return notificationWrap(test(), note);
 }
 
 // A GitHub Check Suite notification
 class Notification {
   constructor(name, e, p) {
-      this.proj = p;
-      this.payload = e.payload;
-      this.name = name;
-      this.externalID = e.buildID;
-      this.detailsURL = `https://brigadecore.github.io/kashti/builds/${ e.buildID }`;
-      this.title = "running check";
-      this.text = "";
-      this.summary = "";
+    this.proj = p;
+    this.payload = e.payload;
+    this.name = name;
+    this.externalID = e.buildID;
+    this.detailsURL = `https://brigadecore.github.io/kashti/builds/${ e.buildID }`;
+    this.title = "running check";
+    this.text = "";
+    this.summary = "";
 
-      // count allows us to send the notification multiple times, with a distinct pod name
-      // each time.
-      this.count = 0;
+    // count allows us to send the notification multiple times, with a distinct pod name
+    // each time.
+    this.count = 0;
 
-      // One of: "success", "failure", "neutral", "cancelled", or "timed_out".
-      this.conclusion = "neutral";
+    // One of: "success", "failure", "neutral", "cancelled", or "timed_out".
+    this.conclusion = "neutral";
   }
 
   // Send a new notification, and return a Promise<result>.
   run() {
-      this.count++
-      var j = new Job(`${ this.name }-notification-${ this.count }`, "brigadecore/brigade-github-check-run:latest");
-      j.imageForcePull = true;
-      j.env = {
-          CHECK_CONCLUSION: this.conclusion,
-          CHECK_NAME: this.name,
-          CHECK_TITLE: this.title,
-          CHECK_PAYLOAD: this.payload,
-          CHECK_SUMMARY: this.summary,
-          CHECK_TEXT: this.text,
-          CHECK_DETAILS_URL: this.detailsURL,
-          CHECK_EXTERNAL_ID: this.externalID
-      }
-      return j.run();
+    this.count++;
+    var job = new Job(`${ this.name }-notification-${ this.count }`, "brigadecore/brigade-github-check-run:latest");
+    job.imageForcePull = true;
+    job.env = {
+      "CHECK_CONCLUSION": this.conclusion,
+      "CHECK_NAME": this.name,
+      "CHECK_TITLE": this.title,
+      "CHECK_PAYLOAD": this.payload,
+      "CHECK_SUMMARY": this.summary,
+      "CHECK_TEXT": this.text,
+      "CHECK_DETAILS_URL": this.detailsURL,
+      "CHECK_EXTERNAL_ID": this.externalID
+    };
+    return job.run();
   }
 }
 
 // Helper to wrap a job execution between two notifications.
-async function notificationWrap(job, note, conclusion) {
-  if (conclusion == null) {
-      conclusion = "success"
-  }
+async function notificationWrap(job, note) {
   await note.run();
   try {
-      let res = await job.run()
-      const logs = await job.logs();
-
-      note.conclusion = conclusion;
-      note.summary = `Task "${ job.name }" passed`;
-      note.text = note.text = "```" + res.toString() + "```\nTest Complete";
-      return await note.run();
+    let res = await job.run();
+    const logs = await job.logs();
+    note.conclusion = "success";
+    note.summary = `Task "${ job.name }" passed`;
+    note.text = note.text = "```" + res.toString() + "```\nTest Complete";
+    return await note.run();
   } catch (e) {
-      const logs = await job.logs();
-      note.conclusion = "failure";
-      note.summary = `Task "${ job.name }" failed for ${ e.buildID }`;
-      note.text = "```" + logs + "```\nFailed with error: " + e.toString();
-      try {
-          return await note.run();
-      } catch (e2) {
-          console.error("failed to send notification: " + e2.toString());
-          console.error("original error: " + e.toString());
-          return e2;
-      }
+    const logs = await job.logs();
+    note.conclusion = "failure";
+    note.summary = `Task "${ job.name }" failed for ${ e.buildID }`;
+    note.text = "```" + logs + "```\nFailed with error: " + e.toString();
+    try {
+      return await note.run();
+    } catch (e2) {
+      console.error("failed to send notification: " + e2.toString());
+      console.error("original error: " + e.toString());
+      return e2;
+    }
   }
 }
 
 events.on("exec", (e, p) => {
-  return test(e, p).run()
+  return test(e, p).run();
 })
 
 events.on("push", (e, p) => {
@@ -166,6 +160,6 @@ events.on("push", (e, p) => {
   }
 })
 
-events.on("check_suite:requested", runSuite)
-events.on("check_suite:rerequested", runSuite)
-events.on("check_run:rerequested", runSuite)
+events.on("check_suite:requested", runSuite);
+events.on("check_suite:rerequested", runSuite);
+events.on("check_run:rerequested", runSuite);


### PR DESCRIPTION
This is a small follow-up to #59 

1. Minor formatting / style fixes on `brigade.js`-- add missing semicolons and remove unused variables, for instance, and quote string literal keys in maps for clarity.

2. Improve how git short shas are calculated during the build / release process. After working on changes similar to those in #59 on the main brigade project, I noticed something odd about the process that we were using here-- it builds off the last _annotated_ tag (if there is one). i.e. You get `<last annotated tag>-<number of commits beyond that tag>-<git sha>` and that was not what I ever intended. The new logic will _never_ match any tag and will always fall back on using just the short sha of HEAD.