### PR TITLE
don't swallow errors on master build / release

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -23,19 +23,13 @@ events.on("push", (e, p) => {
     // This is an official release with a semantically versioned tag
     let matchTokens = Array.from(matchStr);
     let version = matchTokens[1];
-    buildAndPublishImages(p, version).run()
-    .catch((err) => {
-      console.error(err.toString());
-    });
+    return buildAndPublishImages(p, version).run();
   }
   if (e.revision.ref == "refs/heads/master") {
     // This runs tests then builds and publishes "edge" images
-    test().run()
+    return test().run()
     .then(() => {
       buildAndPublishImages(p, "").run();
-    })
-    .catch((err) => {
-      console.error(err.toString());
     });
   }
 })


### PR DESCRIPTION
Our handler for the `push` even is still swallowing errors and preventing builds from failing when they ought to. This fixes that.

See #68, which fixed the same condition for a different event.