### PR TITLE
make shouldEmit more efficient and more readable

### DIFF
--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -656,17 +656,10 @@ func (s *githubHook) isAllowedAuthor(author string) bool {
 }
 
 func (s *githubHook) shouldEmit(eventType string) bool {
-	eventAction := strings.Split(eventType, ":")
-
-	var event, action string
-	event = eventAction[0]
-	if len(eventAction) > 1 {
-		action = eventAction[1]
-	}
-
-	for _, e := range s.opts.EmittedEvents {
-
-		if e == "*" || e == event || e == event+":"+action {
+	unqualifiedEventType := strings.Split(eventType, ":")[0]
+	for _, emitableEvent := range s.opts.EmittedEvents {
+		if eventType == emitableEvent || unqualifiedEventType == emitableEvent ||
+			emitableEvent == "*" {
 			return true
 		}
 	}


### PR DESCRIPTION
The existing logic for determining if an event is whitelisted to be emitted into brigade attempts to decompose the event into an event + action tuple... but then later reassembles it.

This PR eliminates that inefficiency and renames some variables to also make this more readable and intuitive.