### PR TITLE
don't export JWT func

### DIFF
--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -128,7 +128,7 @@ func (s *githubHook) installationToken(appID, installationID int, cfg brigade.Gi
 	aidStr := strconv.Itoa(appID)
 	// We need to perform auth here, and then inject the token into the
 	// body so that the app can use it.
-	tok, err := JWT(aidStr, s.key)
+	tok, err := getSignedJSONWebToken(aidStr, s.key)
 	if err != nil {
 		return "", time.Time{}, err
 	}

--- a/pkg/webhook/crypto.go
+++ b/pkg/webhook/crypto.go
@@ -19,19 +19,19 @@ func SHA1HMAC(salt, message []byte) string {
 	return fmt.Sprintf("sha1=%x", sum)
 }
 
-func JWT(appID string, keyPEM []byte) (string, error) {
+// getSignedJSONWebToken returns a signed JSON web token.
+func getSignedJSONWebToken(appID string, keyPEM []byte) (string, error) {
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(keyPEM)
 	if err != nil {
 		return "", err
 	}
-
 	now := time.Now()
-	claim := &jwt.StandardClaims{
-		IssuedAt:  now.Unix(),
-		ExpiresAt: now.Add(5 * time.Minute).Unix(),
-		Issuer:    appID,
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claim)
-	return token.SignedString(key)
+	return jwt.NewWithClaims(
+		jwt.SigningMethodRS256,
+		jwt.StandardClaims{
+			IssuedAt:  now.Unix(),
+			ExpiresAt: now.Add(5 * time.Minute).Unix(),
+			Issuer:    appID,
+		},
+	).SignedString(key)
 }


### PR DESCRIPTION
The `JWT()` function doesn't need to be exported since it's a helper only used within its own package.

This PR also renames the function and comments it, both in the name of making its purpose more
clear.