### PR TITLE
feat: error reporting with issue and pr comments

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -492,6 +492,7 @@
     "util/homedir",
     "util/integer",
     "util/retry",
+    "util/workqueue",
   ]
   pruneopts = ""
   revision = "36368dede29baa5ecd253416d70ddc0c76bde69b"
@@ -509,6 +510,12 @@
     "golang.org/x/oauth2",
     "gopkg.in/gin-gonic/gin.v1",
     "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/fields",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/util/workqueue",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,5 +17,13 @@
   branch = "release-1.10"
 
 [[constraint]]
+  name = "k8s.io/apimachinery"
+  branch = "release-1.10"
+
+[[constraint]]
+  name = "k8s.io/client-go"
+  branch = "release-7.0"
+
+[[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.1"

--- a/pkg/webhook/buildopts.go
+++ b/pkg/webhook/buildopts.go
@@ -12,7 +12,7 @@ type buildOpts struct {
 	issueID int
 }
 
-func (s *githubHook) icePayloadToBuildOpts(ice *github.IssueCommentEvent, proj *brigade.Project, payload []byte) buildOpts {
+func (s *githubHook) icePayloadToBuildOpts(ice *github.IssueCommentEvent, proj *brigade.Project, payload []byte) (buildOpts, error) {
 	opts := buildOpts{}
 	if ice != nil {
 		// Reuse the installation token generated for the payload if exists
@@ -23,26 +23,32 @@ func (s *githubHook) icePayloadToBuildOpts(ice *github.IssueCommentEvent, proj *
 				opts.tok = res.Token
 			}
 		} else {
-			tok, _, _ := s.iceToIntsallationToken(ice, proj)
+			tok, _, err := s.iceToIntsallationToken(ice, proj)
+			if err != nil {
+				return opts, err
+			}
 			opts.tok = tok
 		}
 
 		opts.issueID = int(ice.GetIssue().GetID())
 	}
-	return opts
+	return opts, nil
 }
 
-func (s *githubHook) preToBuildOpts(pre *github.PullRequestEvent, proj *brigade.Project) buildOpts {
+func (s *githubHook) preToBuildOpts(pre *github.PullRequestEvent, proj *brigade.Project) (buildOpts, error) {
 	opts := buildOpts{}
 	if pre != nil {
-		tok, _, _ := s.prToInstallationToken(pre, proj)
+		tok, _, err := s.prToInstallationToken(pre, proj)
+		if err != nil {
+			return opts, err
+		}
 		if tok != "" {
 			opts.tok = tok
 		}
 
 		opts.issueID = int(pre.GetPullRequest().GetID())
 	}
-	return opts
+	return opts, nil
 }
 
 func (s *githubHook) checkEventToBuildOpts(e interface{}, tok string) buildOpts {

--- a/pkg/webhook/buildopts.go
+++ b/pkg/webhook/buildopts.go
@@ -1,0 +1,58 @@
+package webhook
+
+import (
+	"encoding/json"
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/google/go-github/github"
+)
+
+type buildOpts struct {
+	tok     string
+	issueId int
+}
+
+func (s *githubHook) icePayloadToBuildOpts(ice *github.IssueCommentEvent, proj *brigade.Project, payload []byte) buildOpts {
+	opts := buildOpts{}
+	if ice != nil {
+		// Reuse the installation token generated for the payload if exists
+		if len(payload) > 0 {
+			res := Payload{}
+			_ = json.Unmarshal(payload, &res)
+			if res.Token != "" {
+				opts.tok = res.Token
+			}
+		} else {
+			tok, _, _ := s.iceToIntsallationToken(ice, proj)
+			opts.tok = tok
+		}
+
+		opts.issueId = int(ice.GetIssue().GetID())
+	}
+	return opts
+}
+
+func (s *githubHook) preToBuildOpts(pre *github.PullRequestEvent, proj *brigade.Project) buildOpts {
+	opts := buildOpts{}
+	if pre != nil {
+		tok, _, _ := s.prToInstallationToken(pre, proj)
+		if tok != "" {
+			opts.tok = tok
+		}
+
+		opts.issueId = int(pre.GetPullRequest().GetID())
+	}
+	return opts
+}
+
+func (s *githubHook) checkEventToBuildOpts(e interface{}, tok string) buildOpts {
+	opts := buildOpts{
+		tok: tok,
+	}
+	switch e := e.(type) {
+	case *github.CheckSuiteEvent:
+		opts.issueId = int(e.GetCheckSuite().PullRequests[0].GetID())
+	case *github.CheckRunEvent:
+		opts.issueId = int(e.GetCheckRun().PullRequests[0].GetID())
+	}
+	return opts
+}

--- a/pkg/webhook/buildopts.go
+++ b/pkg/webhook/buildopts.go
@@ -2,13 +2,14 @@ package webhook
 
 import (
 	"encoding/json"
+
 	"github.com/brigadecore/brigade/pkg/brigade"
 	"github.com/google/go-github/github"
 )
 
 type buildOpts struct {
 	tok     string
-	issueId int
+	issueID int
 }
 
 func (s *githubHook) icePayloadToBuildOpts(ice *github.IssueCommentEvent, proj *brigade.Project, payload []byte) buildOpts {
@@ -26,7 +27,7 @@ func (s *githubHook) icePayloadToBuildOpts(ice *github.IssueCommentEvent, proj *
 			opts.tok = tok
 		}
 
-		opts.issueId = int(ice.GetIssue().GetID())
+		opts.issueID = int(ice.GetIssue().GetID())
 	}
 	return opts
 }
@@ -39,7 +40,7 @@ func (s *githubHook) preToBuildOpts(pre *github.PullRequestEvent, proj *brigade.
 			opts.tok = tok
 		}
 
-		opts.issueId = int(pre.GetPullRequest().GetID())
+		opts.issueID = int(pre.GetPullRequest().GetID())
 	}
 	return opts
 }
@@ -50,9 +51,9 @@ func (s *githubHook) checkEventToBuildOpts(e interface{}, tok string) buildOpts 
 	}
 	switch e := e.(type) {
 	case *github.CheckSuiteEvent:
-		opts.issueId = int(e.GetCheckSuite().PullRequests[0].GetID())
+		opts.issueID = int(e.GetCheckSuite().PullRequests[0].GetID())
 	case *github.CheckRunEvent:
-		opts.issueId = int(e.GetCheckRun().PullRequests[0].GetID())
+		opts.issueID = int(e.GetCheckRun().PullRequests[0].GetID())
 	}
 	return opts
 }

--- a/pkg/webhook/buildreporter.go
+++ b/pkg/webhook/buildreporter.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -199,7 +199,7 @@ func (c *BuildReporter) Add(b *brigade.Build, issueNumber int, tok string) {
 	}
 
 	c.indexer.Add(&v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: c.ns,
 		},

--- a/pkg/webhook/buildreporter.go
+++ b/pkg/webhook/buildreporter.go
@@ -78,13 +78,17 @@ func (c *BuildReporter) processBuildPod(key string) error {
 			return fmt.Errorf("unexpected phase: %s", phase)
 		}
 
-		ctx := c.podToBuild[pod.Name]
+		ctx, ok := c.podToBuild[pod.Name]
+		if !ok {
+			fmt.Printf("skipping non-brigade pod %s\n", pod.GetName())
+			return nil
+		}
 
 		msg := fmt.Sprintf("Build failed. Please run `brig build logs --init %s` to investigate the cause.", ctx.underlying.ID)
 
 		proj, err := c.store.GetProject(ctx.underlying.ProjectID)
 		if err != nil {
-			c.Logf("%v", err)
+			c.Logf("failed to retrieve project via %s: %v", ctx.underlying.ProjectID, err)
 			return err
 		}
 

--- a/pkg/webhook/buildreporter.go
+++ b/pkg/webhook/buildreporter.go
@@ -1,0 +1,207 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/storage"
+	"github.com/google/go-github/github"
+)
+
+type BuildReporter struct {
+	indexer    cache.Indexer
+	queue      workqueue.RateLimitingInterface
+	informer   cache.Controller
+	store      storage.Store
+	ns         string
+	podToBuild map[string]*commentableBuild
+}
+
+func newBuildReporter(queue workqueue.RateLimitingInterface, indexer cache.Indexer, informer cache.Controller, store storage.Store, ns string) *BuildReporter {
+	return &BuildReporter{
+		informer:   informer,
+		indexer:    indexer,
+		queue:      queue,
+		ns:         ns,
+		store:      store,
+		podToBuild: map[string]*commentableBuild{},
+	}
+}
+
+func (c *BuildReporter) processNextBuildPodUpdate() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+
+	defer c.queue.Done(key)
+
+	err := c.processBuildPod(key.(string))
+
+	c.completeOrRetry(err, key)
+
+	return true
+}
+
+func (c *BuildReporter) processBuildPod(key string) error {
+	obj, exists, err := c.indexer.GetByKey(key)
+	if err != nil {
+		c.Logf("Fetching object with key %s from store failed with %v", key, err)
+		return err
+	}
+
+	if exists {
+		// Note that you also have to check the uid if you have a local controlled resource, which
+		// is dependent on the actual instance, to detect that a Pod was recreated with the same name
+		pod := obj.(*v1.Pod)
+		fmt.Printf("processing pod %s\n", pod.GetName())
+
+		phase := pod.Status.Phase
+		switch phase {
+		case "Running", "Succeeded", "Unknown", "Pending":
+			return nil
+		}
+
+		if phase != "Failed" {
+			return fmt.Errorf("unexpected phase: %s", phase)
+		}
+
+		ctx := c.podToBuild[pod.Name]
+
+		msg := fmt.Sprintf("Build failed. Please run `brig build logs --init %s` to investigate the cause.", ctx.underlying.ID)
+
+		proj, err := c.store.GetProject(ctx.underlying.ProjectID)
+		if err != nil {
+			c.Logf("%v", err)
+			return err
+		}
+
+		client, err := InstallationTokenClient(ctx.installationToken, proj.Github.BaseURL, proj.Github.UploadURL)
+		if err != nil {
+			c.Logf("Failed to create a new installation token client: %s", err)
+			return err
+		}
+
+		ownerRepo := strings.Split(proj.Repo.Name, "/")
+		_, _, err = client.Issues.CreateComment(context.Background(), ownerRepo[0], ownerRepo[1], ctx.issueNumber, &github.IssueComment{
+			Body: &msg,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// completeOrRetry checks if an error happened and makes sure the reporter will retry the errored key later.
+func (c *BuildReporter) completeOrRetry(err error, key interface{}) {
+	if err == nil {
+		// Prevent the next trial on the key from delaying because it has succeeded
+		c.queue.Forget(key)
+		return
+	}
+
+	// Retry at most 5 times on error.
+	if c.queue.NumRequeues(key) < 5 {
+		c.Logf("Error syncing %q: %v", key, err)
+
+		// Re-enqueue the key with delay
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	c.queue.Forget(key)
+
+	c.Logf("Dropping %q: %v", key, err)
+}
+
+func (c *BuildReporter) Run(threadiness int, stopCh chan struct{}) {
+	defer c.queue.ShutDown()
+	c.Logf("Starting build reporter")
+
+	go c.informer.Run(stopCh)
+
+	if !cache.WaitForCacheSync(stopCh, c.informer.HasSynced) {
+		c.Logf("Timed out waiting for caches to sync")
+		return
+	}
+
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	c.Logf("Stopping build reporter")
+}
+
+func (c *BuildReporter) runWorker() {
+	// Note that this isn't a busy loop as it blocks on each dequeue
+	for c.processNextBuildPodUpdate() {
+	}
+}
+
+func NewBuildReporter(clientset *kubernetes.Clientset, store storage.Store, ns string) *BuildReporter {
+	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", ns, fields.Everything())
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	indexer, informer := cache.NewIndexerInformer(podListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		UpdateFunc: func(old interface{}, new interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(new)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+	}, cache.Indexers{})
+
+	controller := newBuildReporter(queue, indexer, informer, store, ns)
+
+	return controller
+}
+
+func (c *BuildReporter) Logf(msg string, v ...interface{}) {
+	log.Printf(msg, v...)
+}
+
+// commentableBuild is a brigade build that is run on a GitHub issue or pull request
+type commentableBuild struct {
+	underlying        *brigade.Build
+	issueNumber       int
+	installationToken string
+}
+
+func (c *BuildReporter) Add(b *brigade.Build, issueNumber int, tok string) {
+	podName := fmt.Sprintf("brigade-worker-%s", b.ID)
+
+	c.podToBuild[podName] = &commentableBuild{
+		underlying:        b,
+		installationToken: tok,
+		issueNumber:       issueNumber,
+	}
+
+	c.indexer.Add(&v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      podName,
+			Namespace: c.ns,
+		},
+	})
+}

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
-	gin "gopkg.in/gin-gonic/gin.v1"
+	"gopkg.in/gin-gonic/gin.v1"
 
 	"github.com/brigadecore/brigade/pkg/brigade"
 	"github.com/brigadecore/brigade/pkg/storage"
@@ -33,6 +33,8 @@ type githubHook struct {
 	allowedAuthors          []string
 	// key is the x509 certificate key as ASCII-armored (PEM) data
 	key []byte
+	// BuildReporter is used for reporting build failures via issue comments
+	BuildReporter *BuildReporter
 }
 
 // GithubOpts provides options for configuring a GitHub hook
@@ -42,12 +44,17 @@ type GithubOpts struct {
 	AppID               int
 	DefaultSharedSecret string
 	EmittedEvents       []string
+	ReportBuildFailures bool
 }
 
 type iceUpdater func(c *gin.Context, s *githubHook, ice *github.IssueCommentEvent, rev brigade.Revision, proj *brigade.Project, body []byte) (brigade.Revision, []byte)
 
 // NewGithubHookHandler creates a GitHub webhook handler.
 func NewGithubHookHandler(s storage.Store, authors []string, x509Key []byte, opts GithubOpts) gin.HandlerFunc {
+	return NewGithubHook(s, authors, x509Key, opts).Handle
+}
+
+func NewGithubHook(s storage.Store, authors []string, x509Key []byte, opts GithubOpts) *githubHook {
 	gh := &githubHook{
 		store:                   s,
 		updateIssueCommentEvent: updateIssueCommentEvent,
@@ -55,7 +62,7 @@ func NewGithubHookHandler(s storage.Store, authors []string, x509Key []byte, opt
 		key:                     x509Key,
 		opts:                    opts,
 	}
-	return gh.Handle
+	return gh
 }
 
 // Handle routes a webhook to its appropriate handler.
@@ -207,7 +214,7 @@ func (s *githubHook) handleEvent(
 		// TODO: do we return here (e.g. stop the PR hook) if we get to this point
 	}
 
-	s.scheduleBuild(eventType, action, rev, body, proj)
+	s.scheduleBuild(eventType, action, rev, body, proj, s.preToBuildOpts(pre, proj))
 
 	c.JSON(http.StatusOK, gin.H{"status": "Complete"})
 }
@@ -289,7 +296,7 @@ func (s *githubHook) handleCheck(
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "JSON encoding error"})
 	}
 
-	s.scheduleBuild(eventType, action, rev, payload, proj)
+	s.scheduleBuild(eventType, action, rev, payload, proj, s.checkEventToBuildOpts(event, tok))
 
 	c.JSON(http.StatusOK, gin.H{"status": "Complete"})
 }
@@ -355,7 +362,7 @@ func (s *githubHook) handleIssueComment(
 		rev.Ref = "refs/heads/master"
 	}
 
-	s.scheduleBuild(eventType, action, rev, payload, proj)
+	s.scheduleBuild(eventType, action, rev, payload, proj, s.icePayloadToBuildOpts(ice, proj, payload))
 
 	c.JSON(http.StatusOK, gin.H{"status": "Complete"})
 }
@@ -369,7 +376,7 @@ func updateIssueCommentEvent(c *gin.Context, s *githubHook, ice *github.IssueCom
 	appID := s.opts.AppID
 	instID := ice.Installation.GetID()
 
-	tok, timeout, err := s.getInstallationToken(appID, int(instID), proj)
+	tok, timeout, err := s.iceToIntsallationToken(ice, proj)
 	if err != nil {
 		log.Printf("Failed to negotiate a token: %s", err)
 		c.JSON(http.StatusForbidden, gin.H{"status": ErrAuthFailed})
@@ -399,7 +406,7 @@ func updateIssueCommentEvent(c *gin.Context, s *githubHook, ice *github.IssueCom
 		InstID:       int(instID),
 		Type:         "issue_comment",
 		Token:        tok,
-		TokenExpires: timeout,
+		TokenExpires: *timeout,
 		Commit:       rev.Commit,
 		Branch:       rev.Ref,
 	}
@@ -461,12 +468,12 @@ func marshalWithGithubPayload(res *Payload, body []byte) ([]byte, error) {
 
 // scheduleBuild schedules a Brigade build both for the raw eventType
 // and for each action of the event, when applicable
-func (s *githubHook) scheduleBuild(eventType, action string, rev brigade.Revision, payload []byte, proj *brigade.Project) {
+func (s *githubHook) scheduleBuild(eventType, action string, rev brigade.Revision, payload []byte, proj *brigade.Project, opts buildOpts) {
 	// Schedule a build using the raw eventType
-	s.build(eventType, rev, payload, proj)
+	s.build(eventType, rev, payload, proj, opts)
 	// For events that have an action, schedule a second build for eventType:action
 	if action != "" {
-		s.build(fmt.Sprintf("%s:%s", eventType, action), rev, payload, proj)
+		s.build(fmt.Sprintf("%s:%s", eventType, action), rev, payload, proj, opts)
 	}
 }
 
@@ -532,10 +539,8 @@ func (s *githubHook) prToCheckSuite(c *gin.Context, pre *github.PullRequestEvent
 	repo := pre.Repo.GetFullName()
 	ref := fmt.Sprintf("refs/pull/%d/head", pre.PullRequest.GetNumber())
 	sha := pre.PullRequest.Head.GetSHA()
-	appID := s.opts.AppID
-	instID := pre.Installation.GetID()
 
-	tok, _, err := s.getInstallationToken(appID, int(instID), proj)
+	tok, _, err := s.prToInstallationToken(pre, proj)
 	if err != nil {
 		log.Printf("Failed to negotiate a token: %s", err)
 		return ErrAuthFailed
@@ -635,9 +640,23 @@ func (s *githubHook) shouldEmit(eventType string) bool {
 }
 
 // build creates a new brigade.Build using the info provided
-func (s *githubHook) build(eventType string, rev brigade.Revision, payload []byte, proj *brigade.Project) error {
+//
+// When a non-empty installation token is present and the --report-build-failures is set,
+// it starts watching the build asynchronously and report back with a GitHub issue/pr comment
+func (s *githubHook) build(eventType string, rev brigade.Revision, payload []byte, proj *brigade.Project, opts buildOpts) error {
+	b, err := s.doBuild(eventType, rev, payload, proj)
+	if err != nil {
+		return err
+	}
+	if opts.tok != "" && opts.issueId != 0 && s.opts.ReportBuildFailures {
+		s.BuildReporter.Add(b, opts.issueId, opts.tok)
+	}
+	return nil
+}
+
+func (s *githubHook) doBuild(eventType string, rev brigade.Revision, payload []byte, proj *brigade.Project) (*brigade.Build, error) {
 	if !s.shouldEmit(eventType) {
-		return nil
+		return nil, nil
 	}
 	b := &brigade.Build{
 		ProjectID: proj.ID,
@@ -646,7 +665,8 @@ func (s *githubHook) build(eventType string, rev brigade.Revision, payload []byt
 		Revision:  &rev,
 		Payload:   payload,
 	}
-	return s.store.CreateBuild(b)
+	err := s.store.CreateBuild(b)
+	return b, err
 }
 
 // validateSignature compares the salted digest in the header with our own computing of the body.

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -211,7 +211,12 @@ func (s *githubHook) handleEvent(
 		// TODO: do we return here (e.g. stop the PR hook) if we get to this point
 	}
 
-	s.scheduleBuild(eventType, action, rev, body, proj, s.preToBuildOpts(pre, proj))
+	opts, err := s.preToBuildOpts(pre, proj)
+	if err != nil {
+		log.Printf("error constructing build opts from pull request event: %v", err)
+	}
+
+	s.scheduleBuild(eventType, action, rev, body, proj, opts)
 
 	c.JSON(http.StatusOK, gin.H{"status": "Complete"})
 }
@@ -359,7 +364,12 @@ func (s *githubHook) handleIssueComment(
 		rev.Ref = "refs/heads/master"
 	}
 
-	s.scheduleBuild(eventType, action, rev, payload, proj, s.icePayloadToBuildOpts(ice, proj, payload))
+	opts, err := s.icePayloadToBuildOpts(ice, proj, payload)
+	if err != nil {
+		log.Printf("error constructing build opts from issue comment event: %v", err)
+	}
+
+	s.scheduleBuild(eventType, action, rev, payload, proj, opts)
 
 	c.JSON(http.StatusOK, gin.H{"status": "Complete"})
 }

--- a/pkg/webhook/token.go
+++ b/pkg/webhook/token.go
@@ -9,6 +9,10 @@ import (
 
 func (s *githubHook) prToInstallationToken(pre *github.PullRequestEvent, proj *brigade.Project) (string, *time.Time, error) {
 	appID := s.opts.AppID
+	if appID == 0 {
+		appID = s.opts.AppID
+	}
+
 	instID := pre.Installation.GetID()
 
 	tok, timeout, err := s.getInstallationToken(appID, int(instID), proj)
@@ -18,6 +22,10 @@ func (s *githubHook) prToInstallationToken(pre *github.PullRequestEvent, proj *b
 
 func (s *githubHook) iceToIntsallationToken(ice *github.IssueCommentEvent, proj *brigade.Project) (string, *time.Time, error) {
 	appID := int(ice.Installation.GetAppID())
+	if appID == 0 {
+		appID = s.opts.AppID
+	}
+
 	instID := ice.Installation.GetID()
 
 	tok, timeout, err := s.getInstallationToken(appID, int(instID), proj)

--- a/pkg/webhook/token.go
+++ b/pkg/webhook/token.go
@@ -1,0 +1,25 @@
+package webhook
+
+import (
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/google/go-github/github"
+	"time"
+)
+
+func (s *githubHook) prToInstallationToken(pre *github.PullRequestEvent, proj *brigade.Project) (string, *time.Time, error) {
+	appID := s.opts.AppID
+	instID := pre.Installation.GetID()
+
+	tok, timeout, err := s.getInstallationToken(appID, int(instID), proj)
+
+	return tok, &timeout, err
+}
+
+func (s *githubHook) iceToIntsallationToken(ice *github.IssueCommentEvent, proj *brigade.Project) (string, *time.Time, error) {
+	appID := int(ice.Installation.GetAppID())
+	instID := ice.Installation.GetID()
+
+	tok, timeout, err := s.getInstallationToken(appID, int(instID), proj)
+
+	return tok, &timeout, err
+}

--- a/pkg/webhook/token.go
+++ b/pkg/webhook/token.go
@@ -1,9 +1,10 @@
 package webhook
 
 import (
+	"time"
+
 	"github.com/brigadecore/brigade/pkg/brigade"
 	"github.com/google/go-github/github"
-	"time"
 )
 
 func (s *githubHook) prToInstallationToken(pre *github.PullRequestEvent, proj *brigade.Project) (string, *time.Time, error) {


### PR DESCRIPTION
`--report-build-failures` enables the comment-back functionality that creates a GitHub issue/pull request comment using the installation token whenever possible.

Implementation-wise, I tried hard to limit changes to ` cmd/github-gateway/server.go` and `webhook.go` minimal, so that the changes to the overall logic is easily reviewable. And it should (hopefully) be clear that it won't affect existing functionality as long as the user doesn't explicitly set `--report-builf-failures`.

Resolves #73