### PR TITLE
update project.yaml to allow privileged jobs

### DIFF
--- a/.brigade/project.yaml
+++ b/.brigade/project.yaml
@@ -18,3 +18,5 @@ spec:
     logLevel: DEBUG
     git:
       cloneURL: https://github.com/brigadecore/brigade-github-app.git
+    jobPolicies:
+      allowPrivileged: true


### PR DESCRIPTION
This should have been included in #103.

This updated project definition is already uploaded to the dogfood cluster, but I like to always have a copy of it in source control as well.